### PR TITLE
fix: advanced search name generation with colons

### DIFF
--- a/frontend/components/advancedSearch/AutocompleteInput/AutocompleteInput.tsx
+++ b/frontend/components/advancedSearch/AutocompleteInput/AutocompleteInput.tsx
@@ -89,6 +89,7 @@ const AutocompleteInput: React.FC<Props> = ({
   const handleSelect = (selection: AutoCompleteOption) => {
     const value = useValueForInput ? selection.value : selection.label;
     setLocalValue(value);
+    onChange && onChange(value);
     handleClose();
   };
 

--- a/frontend/components/advancedSearch/MultiSearchInput/MultiSearchInput.tsx
+++ b/frontend/components/advancedSearch/MultiSearchInput/MultiSearchInput.tsx
@@ -34,7 +34,7 @@ const MultiSearchInput = ({
   pluralLabel,
   defaultPlaceholder,
   operatorOptions,
-  defaultOperator = "",
+  defaultOperator = ":",
   onChange,
 }: Props) => {
   const [inputs, setInputs] = useState<MultiSearchInputValue>(value);


### PR DESCRIPTION
* Making sure MultiSearchInput has ":" as the default operator
* AutocompleteInput now sets the value with a selection